### PR TITLE
manage lease namesapce internally

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -42,7 +43,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/pkg/lease/manager.go
+++ b/pkg/lease/manager.go
@@ -3,20 +3,28 @@ package lease
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	coordv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	//NSEnvVar is containing the value of the namespace leases will be managed at, in case it's empty defaultLeaseNs will be used
+	NSEnvVar       = "MEDIK8S_LEASES"
+	defaultLeaseNs = "medik8s-leases"
 )
 
 type Manager interface {
@@ -49,18 +57,55 @@ func (l *manager) InvalidateLease(ctx context.Context, obj client.Object) error 
 	return l.invalidateLease(ctx, obj)
 }
 
-func NewManager(cl client.Client, holderIdentity string, namespace string) Manager {
-	return NewManagerWithCustomLogger(cl, holderIdentity, namespace, ctrl.Log.WithName("leaseManager"))
+func NewManager(cl client.Client, holderIdentity string) (Manager, error) {
+	return NewManagerWithCustomLogger(cl, holderIdentity, ctrl.Log.WithName("leaseManager"))
 
 }
 
-func NewManagerWithCustomLogger(cl client.Client, holderIdentity string, namespace string, log logr.Logger) Manager {
+func setupLeaseNs(cl client.Client, log logr.Logger, leaseNsName string) error {
+	ns := &v1.Namespace{}
+	key := apitypes.NamespacedName{Name: leaseNsName}
+	if err := cl.Get(context.Background(), key, ns); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "couldn't get lease namespace", "namespace", leaseNsName)
+			return errors.Wrap(err, "couldn't get lease namespace")
+		}
+		if err := createLeaseNs(cl, leaseNsName); err != nil {
+			log.Error(err, "couldn't create lease namespace", "namespace", leaseNsName)
+			return errors.Wrap(err, "couldn't create lease namespace")
+		}
+	}
+	return nil
+}
+
+func getLeaseNsName() string {
+	leaseNsName := defaultLeaseNs
+	if leaseNsOverride, ok := os.LookupEnv(NSEnvVar); ok {
+		leaseNsName = leaseNsOverride
+	}
+	return leaseNsName
+}
+
+func createLeaseNs(cl client.Client, leaseNsName string) error {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: leaseNsName,
+		},
+	}
+	return cl.Create(context.Background(), ns)
+}
+
+func NewManagerWithCustomLogger(cl client.Client, holderIdentity string, log logr.Logger) (Manager, error) {
+	leaseNsName := getLeaseNsName()
+	if err := setupLeaseNs(cl, log, leaseNsName); err != nil {
+		return nil, err
+	}
 	return &manager{
 		Client:         cl,
 		holderIdentity: holderIdentity,
-		namespace:      namespace,
+		namespace:      leaseNsName,
 		log:            log,
-	}
+	}, nil
 }
 
 func (l *manager) createLease(ctx context.Context, obj client.Object, duration time.Duration) error {
@@ -157,7 +202,7 @@ func (l *manager) invalidateLease(ctx context.Context, obj client.Object) error 
 	log.Info("invalidating lease")
 	lease, err := l.getLease(ctx, obj)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
@@ -231,7 +276,7 @@ func (l *manager) getLease(ctx context.Context, obj client.Object) (*coordv1.Lea
 	lease := &coordv1.Lease{}
 
 	if err := l.Client.Get(ctx, nName, lease); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			l.log.Error(err, "couldn't fetch lease")
 		}
 		return nil, err

--- a/pkg/lease/manager.go
+++ b/pkg/lease/manager.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	//NSEnvVar is containing the value of the namespace leases will be managed at, in case it's empty defaultLeaseNs will be used
-	NSEnvVar       = "MEDIK8S_LEASES"
-	defaultLeaseNs = "medik8s-leases"
+	NSEnvVar       = "COMMON_MANAGER_LEASES"
+	defaultLeaseNs = "common-manager-leases"
 )
 
 type Manager interface {

--- a/pkg/lease/manager.go
+++ b/pkg/lease/manager.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	//NSEnvVar is containing the value of the namespace leases will be managed at, in case it's empty defaultLeaseNs will be used
-	NSEnvVar       = "COMMON_MANAGER_LEASES"
-	defaultLeaseNs = "common-manager-leases"
+	NSEnvVar       = "LEASE_NAMESPACE"
+	defaultLeaseNs = "medik8s-leases"
 )
 
 type Manager interface {

--- a/pkg/lease/manager_test.go
+++ b/pkg/lease/manager_test.go
@@ -25,7 +25,7 @@ var NowTime = metav1.NowMicro()
 const (
 	leaseHolderIdentity = "some-operator"
 	leaseDuration       = 3600 * time.Second
-	leaseNamespace      = "medik8s-leases"
+	leaseNamespace      = "common-manager-leases"
 )
 
 func getMockNode() *corev1.Node {

--- a/pkg/lease/manager_test.go
+++ b/pkg/lease/manager_test.go
@@ -25,7 +25,7 @@ var NowTime = metav1.NowMicro()
 const (
 	leaseHolderIdentity = "some-operator"
 	leaseDuration       = 3600 * time.Second
-	leaseNamespace      = "common-manager-leases"
+	leaseNamespace      = "medik8s-leases"
 )
 
 func getMockNode() *corev1.Node {

--- a/pkg/lease/manager_test.go
+++ b/pkg/lease/manager_test.go
@@ -25,7 +25,7 @@ var NowTime = metav1.NowMicro()
 const (
 	leaseHolderIdentity = "some-operator"
 	leaseDuration       = 3600 * time.Second
-	leaseNamespace      = "some-lease-namespace"
+	leaseNamespace      = "medik8s-leases"
 )
 
 func getMockNode() *corev1.Node {
@@ -68,7 +68,7 @@ var _ = Describe("Leases", func() {
 				initialLease,
 			}
 			cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-			manager := NewManager(cl, leaseHolderIdentity, leaseNamespace)
+			manager, _ := NewManager(cl, leaseHolderIdentity)
 			_, err := manager.GetLease(context.TODO(), node)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -561,7 +561,7 @@ func generateExpectedLease(obj client.Object, kind string) *coordv1.Lease {
 func testCreateLease() {
 	node := getMockNode()
 	cl := fake.NewClientBuilder().Build()
-	manager := NewManager(cl, leaseHolderIdentity, leaseNamespace)
+	manager, _ := NewManager(cl, leaseHolderIdentity)
 	_, err := manager.GetLease(context.Background(), node)
 	Expect(err.Error()).To(ContainSubstring("not found"))
 	err = manager.RequestLease(context.Background(), node, leaseDuration)


### PR DESCRIPTION
Managing lease namespace internally, so it may be relevant when used by different operators