### PR TITLE
Adding a default template label

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -7,6 +7,6 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
-	// DefaultTemplate is a label that would be set in case a remediator may have several remediation templates in order to signal to the UI which one is the default
+	// DefaultTemplate label indicates to third party tools (e.g. UI) the default remediation template in case several exists.
 	DefaultTemplate = "remediation.medik8s.io/default-template"
 )

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -7,4 +7,6 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
+	// DefaultTemplate is a label that would be set in case a remediator may have several remediation templates in order to signal to the UI which one is the default
+	DefaultTemplate = "remediation.medik8s.io/default-template"
 )


### PR DESCRIPTION
 [ECOPROJECT-1759](https://issues.redhat.com//browse/ECOPROJECT-1759)

ATM The UI is looking for SNR Template with the default remediation strategy completely hard coded (i.e hard coded for ResourceDeletion).
In order to make the UI more robust and prevent unnecessary changes in the UI when the default Strategy is changed, we'd put a label on the Template with the default strategy instead.