### PR TITLE
Add common API to emit events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
+	k8s.io/client-go v0.26.3
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.5
 )
@@ -65,7 +66,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
-	k8s.io/client-go v0.26.3 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+// Event message format "medik8s <operator shortname> <message>"
+const customFmt = "[remediation] %s"
+
+// NormalEventf will record an event with type Normal and fixed message.
+func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
+	recorder.Event(object, "Normal", reason, fmt.Sprintf("[remediation] %s", message))
+}
+
+// NormalEventf will record an event with type Normal and formatted message.
+func NormalEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
+	message := fmt.Sprintf(messageFmt, a...)
+	recorder.Event(object, "Normal", reason, fmt.Sprintf("[remediation] %s", message))
+}
+
+// WarningEventf will record an event with type Warning and fixed message.
+func WarningEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
+	recorder.Event(object, "Warning", reason, fmt.Sprintf("[remediation] %s", message))
+}
+
+// WarningEventf will record an event with type Warning and formatted message.
+func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
+	message := fmt.Sprintf(messageFmt, a...)
+	recorder.Event(object, "Warning", reason, fmt.Sprintf("[remediation] %s", message))
+}
+
+// Special case events
+
+// RemediationStarted will record a Normal event with reason RemediationStarted and message Remediation started.
+func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
+}
+
+// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped.
+func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
+}
+
+// RemediationFinished will record a Normal event with reason RemediationFinished and message Remediation finished.
+func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -10,26 +11,26 @@ import (
 // Event message format "medik8s <operator shortname> <message>"
 const customFmt = "[remediation] %s"
 
-// NormalEventf will record an event with type Normal and fixed message.
+// NormalEvent will record an event with type Normal and fixed message.
 func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
-	recorder.Event(object, "Normal", reason, fmt.Sprintf("[remediation] %s", message))
+	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
 
 // NormalEventf will record an event with type Normal and formatted message.
 func NormalEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
 	message := fmt.Sprintf(messageFmt, a...)
-	recorder.Event(object, "Normal", reason, fmt.Sprintf("[remediation] %s", message))
+	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
 
-// WarningEventf will record an event with type Warning and fixed message.
+// WarningEvent will record an event with type Warning and fixed message.
 func WarningEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
-	recorder.Event(object, "Warning", reason, fmt.Sprintf("[remediation] %s", message))
+	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
 }
 
 // WarningEventf will record an event with type Warning and formatted message.
 func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
 	message := fmt.Sprintf(messageFmt, a...)
-	recorder.Event(object, "Warning", reason, fmt.Sprintf("[remediation] %s", message))
+	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
 }
 
 // Special case events

--- a/pkg/events/events_suite_test.go
+++ b/pkg/events/events_suite_test.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestEvents(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Events Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// call start or refactor when moving to "normal" testEnv test
+})
+
+var _ = AfterSuite(func() {
+	// call stop or refactor when moving to "normal" testEnv test
+})

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,68 @@
+package events
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+var r *record.FakeRecorder
+
+var _ = Describe("Emit custom formatted Event", func() {
+	BeforeEach(func() {
+		r = record.NewFakeRecorder(4)
+	})
+
+	Context("Emit event via custom API", func() {
+		DescribeTable("Custom APIs",
+			func(obj runtime.Object, eventType string, eventReason string, message string, expected string, args ...interface{}) {
+				if eventType == "Normal" {
+					if len(args) != 0 {
+						NormalEventf(r, obj, eventReason, message, args...)
+					} else {
+						NormalEvent(r, obj, eventReason, message)
+					}
+				} else {
+					if len(args) != 0 {
+						WarningEventf(r, obj, eventReason, message, args...)
+					} else {
+						WarningEvent(r, obj, eventReason, message)
+					}
+				}
+				for {
+					select {
+					case got := <-r.Events:
+						Expect(got).To(Equal(expected))
+						break
+					case <-time.After(1 * time.Second):
+						Fail("Timeout waiting for event")
+					}
+					break
+
+				}
+			},
+			Entry("Emit normal event",
+				nil,
+				"Normal", "thisReason", "normal event message",
+				"Normal thisReason [remediation] normal event message"),
+			Entry("Emit normal event with args",
+				nil,
+				"Normal", "thisReason", "normal event message with some arguments: %s%d, %s%d",
+				"Normal thisReason [remediation] normal event message with some arguments: somevalue1, somevalue2",
+				"somevalue", 1, "somevalue", 2),
+			Entry("Emit warning event",
+				nil,
+				"Warning", "thisReason", "warning event message",
+				"Warning thisReason [remediation] warning event message"),
+			Entry("Emit warning event with args",
+				nil,
+				"Warning", "thisReason", "warning event message with some arguments: %s%d, %s%d",
+				"Warning thisReason [remediation] warning event message with some arguments: somevalue1, somevalue2",
+				"somevalue", 1, "somevalue", 2),
+		)
+	})
+})


### PR DESCRIPTION
Add common API to emit Events to share the same format among operators.
