### PR TITLE
[WIP] Add Mutual Events Reasons and Messages Between Remediators

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,43 @@
+package events
+
+const (
+
+	// types
+	EventTypeNormal  = "Normal"
+	EventTypeWarning = "Warning"
+
+	// reasons
+	EventReasonRemediationCreated      = "RemediationCreated"
+	EventReasonRemediationStoppedByNHC = "RemediationStoppedByNHC"
+	EventReasonAddFinalizer            = "AddFinalizer"
+	EventReasonRemoveFinalizer         = "RemoveFinalizer"
+	EventReasonNodeRemediated          = "NodeRemediated"
+
+	// shared between snr and far
+	EventReasonDeleteResources      = "DeleteResources"
+	EventReasonAddNoExecuteTaint    = "AddNoExecuteTaint"
+	EventReasonRemoveNoExecuteTaint = "RemoveNoExecuteTaint"
+	EventReasonNodeRebooted         = "NodeRebooted"
+
+	// messages
+
+	RemediationProccessedPrefix = "Remediation process"
+	MessagePrefixFAR = "medik8s-far "
+	MessagePrefixSNR = "medik8s-snr "
+	MessagePrefixMDR = "medik8s-mdr "
+
+	EventMessageRemediationCreated      = "Remediation was created"
+	EventMessageRemediationStoppedByNHC = "Remediation was stopped by the Node Healthcheck Operator"
+	EventMessageAddFinalizer            = "Finalizer was added"
+	EventMessageRemoveFinalizer         = "Finalizer was removed"
+	EventMessageNodeRemediated          = "Unhealthy node was remediated"
+
+	// shared between snr and far
+	EventMessageDeleteResources      = "Manually delete pods from the unhealthy node"
+	EventMessageAddNoExecuteTaint    = "NoExecute taint was added"
+	EventMessageRemoveNoExecuteTaint = "NoExecute taint was removed"
+	EventMessageNodeRebooted         = "Unhealthy node was rebooted"
+
+	EventMessageAddOutOfServiceTaint    = "Add out-of-service taint"
+	EventMessageRemoveOutOfServiceTaint = "Remove out-of-service taint"
+)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,10 +1,19 @@
 package events
 
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
 const (
 
+	// Event message format "medik8s <operator shortname> <message>"
+	format = "medik8s %3s %s"
 	// types
-	EventTypeNormal  = "Normal"
-	EventTypeWarning = "Warning"
+	eventTypeNormal  = "Normal"
+	eventTypeWarning = "Warning"
 
 	// reasons
 	EventReasonRemediationCreated      = "RemediationCreated"
@@ -21,23 +30,81 @@ const (
 
 	// messages
 
-	RemediationProccessedPrefix = "Remediation process"
-	MessagePrefixFAR = "medik8s-far "
-	MessagePrefixSNR = "medik8s-snr "
-	MessagePrefixMDR = "medik8s-mdr "
-
-	EventMessageRemediationCreated      = "Remediation was created"
-	EventMessageRemediationStoppedByNHC = "Remediation was stopped by the Node Healthcheck Operator"
-	EventMessageAddFinalizer            = "Finalizer was added"
-	EventMessageRemoveFinalizer         = "Finalizer was removed"
-	EventMessageNodeRemediated          = "Unhealthy node was remediated"
+	eventMessageRemediationCreated      = "Remediation was created"
+	eventMessageRemediationStoppedByNHC = "Remediation was stopped by the Node Healthcheck Operator"
+	eventMessageAddFinalizer            = "Finalizer was added"
+	eventMessageRemoveFinalizer         = "Finalizer was removed"
+	eventMessageNodeRemediated          = "Unhealthy node was remediated"
 
 	// shared between snr and far
-	EventMessageDeleteResources      = "Manually delete pods from the unhealthy node"
-	EventMessageAddNoExecuteTaint    = "NoExecute taint was added"
-	EventMessageRemoveNoExecuteTaint = "NoExecute taint was removed"
-	EventMessageNodeRebooted         = "Unhealthy node was rebooted"
+	eventMessageDeleteResources      = "Manually delete pods from the unhealthy node"
+	eventMessageAddNoExecuteTaint    = "NoExecute taint was added"
+	eventMessageRemoveNoExecuteTaint = "NoExecute taint was removed"
+	eventMessageNodeRebooted         = "Unhealthy node was rebooted"
 
-	EventMessageAddOutOfServiceTaint    = "Add out-of-service taint"
-	EventMessageRemoveOutOfServiceTaint = "Remove out-of-service taint"
+	eventMessageAddOutOfServiceTaint    = "Add out-of-service taint"
+	eventMessageRemoveOutOfServiceTaint = "Remove out-of-service taint"
+
+	// error
+	unknownOperator= "UnknownOperator"
 )
+
+type EventRecorder struct {
+	record.EventRecorder
+	operator string
+}
+
+
+// EventGenerator generates an event for the far CR
+func (e *EventRecorder) EventGenerator(obj runtime.Object, eventReason string) {
+	eventType, eventMessage := EventCreator(eventReason, e.operator)
+	e.Event(obj, eventType, eventReason, fmt.Sprintf(format, e.operator, eventMessage))
+}
+
+// EventCreator returns the evnetType and eventMessage based on the eventReason input
+func EventCreator(eventReason, operatorName string) (string, string) {
+	var eventMessage string
+	eventType := eventTypeNormal
+	switch eventReason {
+	case EventReasonRemediationCreated:
+		eventMessage = eventMessageRemediationCreated
+	case EventReasonRemediationStoppedByNHC:
+		eventMessage = eventMessageRemediationStoppedByNHC
+	case EventReasonAddFinalizer:
+		eventMessage = eventMessageAddFinalizer
+	case EventReasonRemoveFinalizer:
+		eventMessage = eventMessageRemoveFinalizer
+	case EventReasonNodeRemediated:
+		eventMessage = eventMessageNodeRemediated
+	default:
+		// try operator specefic  events
+		switch operatorName{
+		case "far":
+			eventType, eventMessage = EventCreatorFar(eventReason)
+		default :
+			eventType, eventMessage = unknownOperator, unknownOperator
+		}
+	}
+	return eventType, eventMessage
+}
+
+// EventCreatorFar returns the evnetType and eventMessage based on the eventReason input for far cr
+func EventCreatorFar(eventReason string) (string, string) {
+	var eventMessage string
+	eventType := eventTypeNormal
+	switch eventReason {
+	case EventReasonRemoveNoExecuteTaint:
+		eventMessage = eventMessageRemoveNoExecuteTaint
+	case EventReasonAddNoExecuteTaint:
+		eventMessage = eventMessageAddNoExecuteTaint
+	case EventReasonNodeRebooted:
+		eventMessage = eventMessageNodeRebooted
+	case EventReasonDeleteResources:
+		eventMessage = eventMessageDeleteResources
+	default:
+		eventType = eventTypeWarning
+		eventMessage = "unknonwn event reason"
+	}
+	return eventType, eventMessage
+}
+


### PR DESCRIPTION
I think we can benefit from having shared events reasons and messages between remediators.

1. List of shared events reasons and messages
2. Create events using `EventRecorder`, and `EventGenerator` in a generic way that could be used for unit testing.  Instead of hard-coding the type, reason, and message once, and then creating the triple by only knowing the _reason_.
3. Specific events reasons and messages that we could include here or leave them inside each repo.