### PR TITLE
Check etcd quorum for Control Plane Remediation/Maintenance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.3
-	github.com/go-logr/zapr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/pkg/errors v0.9.1
@@ -25,6 +24,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/go-logr/zapr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
+	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3
@@ -23,7 +25,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -51,7 +52,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -8,31 +8,45 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const etcdNamespace = "openshift-etcd"
 
-// IsEtcdDisruptionAllowed checks if etcd disruption is allowed and accpet/refuse the todoAction (remediation/manitenance)
-func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, node *corev1.Node, todoAction string) (bool, error) {
-	log := log.Log.WithName("etcd-pdb-checker")
+var log = logf.Log.WithName("etcd-pdb-checker")
+
+// isEtcdDisruptionAllowed checks if etcd disruption is allowed and refuse the todoAction (remediation/manitenance) when it isn't allowed
+func isEtcdDisruptionAllowed(ctx context.Context, cl client.Client, todoAction string) (bool, *policyv1.PodDisruptionBudget, error) {
 	pdbList := &policyv1.PodDisruptionBudgetList{}
 	if err := cl.List(ctx, pdbList, &client.ListOptions{Namespace: etcdNamespace}); err != nil {
-		return false, err
+		return false, nil, err
 	}
 	if len(pdbList.Items) == 0 {
 		log.Info("No PDB found, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "namespace", etcdNamespace)
-		return false, nil
+		return false, nil, nil
 	}
 	if len(pdbList.Items) > 1 {
 		log.Info("More than one PDB found, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "namespace", etcdNamespace)
-		return false, nil
+		return false, nil, nil
 	}
 	pdb := pdbList.Items[0]
 	if pdb.Status.DisruptionsAllowed >= 1 {
+		return true, &pdb, nil
+	}
+	return false, &pdb, nil
+}
+
+// IsControlPlaneNodeReady checks if etcd disruption is allowed and accpet/refuse the todoAction (remediation/manitenance)
+func IsControlPlaneNodeReady(ctx context.Context, cl client.Client, node *corev1.Node, todoAction string) (bool, error) {
+	allowedDisruption, pdb, err := isEtcdDisruptionAllowed(ctx, cl, todoAction)
+	if pdb == nil {
+		return false, err
+	}
+	if allowedDisruption {
 		log.Info("Etcd disruption is allowed, so "+todoAction+" is allowed", "Node", node.Name)
 		return true, nil
 	}
+	log.Info("ETCD PDB was found but etcd disruption isn't allowed - DisruptionsAllowed = 0", "Node", node.Name)
 
 	// No disruptions allowed, so the only case we should remediate is that the node in question is already one of the disrupted ones
 	// The PDB doesn't disclose which node is disrupted
@@ -40,7 +54,7 @@ func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, node *corev1
 	selector, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
 	if err != nil {
 		log.Info("Could not parse PDB selector, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "selector", pdb.Spec.Selector.String())
-		return false, nil
+		return false, err
 	}
 	podList := &corev1.PodList{}
 	if err := cl.List(ctx, podList, &client.ListOptions{
@@ -53,15 +67,15 @@ func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, node *corev1
 		if pod.Spec.NodeName == node.Name {
 			for _, condition := range pod.Status.Conditions {
 				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
-					log.Info("Etcd disruption is not allowed, but the node is already disrupted, so "+todoAction+" is allowed", "Node", node.Name, "Guard pod", pod.Name)
+					log.Info("Node is disrupted, so "+todoAction+" is allowed", "Node", node.Name, "Guard pod", pod.Name)
 					return true, nil
 				}
 			}
-			log.Info("Etcd disruption is not allowed, but the node is not disrupted, so "+todoAction+" is not allowed", "Node", node.Name, "Guard pod", pod.Name)
+			log.Info("Node is not disrupted, so "+todoAction+" is not allowed", "Node", node.Name, "Guard pod", pod.Name)
 			return false, nil
 		}
 	}
 
-	log.Info("Etcd disruption is not allowed, and node is not already disrupted, so "+todoAction+" is not allowed", "Node", node.Name)
+	log.Info("Node is not disrupted, so "+todoAction+" is not allowed", "Node", node.Name)
 	return false, nil
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1,45 +1,45 @@
+// etcd package is used for checking whether etcd disruption is allowd
+// Important: add the following two lines in your project/code, so your RBAC will be updated with the right permissions
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 package etcd
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-// Important: add the following two lines in your project/code, so your RBAC will be updated with the right permissions
-// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 const (
-	etcdNamespace = "openshift-etcd"
-	errNoEtcdChec = "can't check if etcd quorum will be violated!"
+	etcdNamespace  = "openshift-etcd"
+	errNoEtcdCheck = "can't check if the etcd quorum will be violated!"
 )
 
-var log = logf.Log.WithName("etcd-pdb-checker")
-
-// CanNodeDisruptEtcd checks if a node can disrupt etcd quorum, and it returns error when it fails in the process
-func CanNodeDisruptEtcd(ctx context.Context, cl client.Client, node *corev1.Node) (bool, error) {
-	// Check if etcd is already disrupted, and if new disruption is allowed
+// IsEtcdDisruptionAllowed checks if etcd disruption is allowed fot a given node
+func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, log logr.Logger, node *corev1.Node) (bool, error) {
+	// Check if new disruption is allowed
 	pdbList := &policyv1.PodDisruptionBudgetList{}
 	if err := cl.List(ctx, pdbList, &client.ListOptions{Namespace: etcdNamespace}); err != nil {
 		return false, err
 	}
 	if len(pdbList.Items) == 0 {
-		log.Info("No PDB were found, "+errNoEtcdChec, "namespace", etcdNamespace)
+		log.Info(fmt.Sprintf("No PDBs were found, %s", errNoEtcdCheck), "namespace", etcdNamespace)
 		return false, nil
 	}
 	if len(pdbList.Items) > 1 {
-		log.Info("More than one PDB found, "+errNoEtcdChec, "namespace", etcdNamespace)
+		log.Info(fmt.Sprintf("More than one PDB found, %s", errNoEtcdCheck), "namespace", etcdNamespace)
 		return false, nil
 	}
 	pdb := pdbList.Items[0]
 	if pdb.Status.DisruptionsAllowed >= 1 {
-		log.Info("Node disruption is allowed, since etcd disruption is allowed", "Node", node.Name)
+		log.Info("etcd disruption is allowed, thus mode disruption is allowed, ", "Node", node.Name)
 		return true, nil
 	}
 
@@ -51,7 +51,7 @@ func CanNodeDisruptEtcd(ctx context.Context, cl client.Client, node *corev1.Node
 	// So we have to check the etcd guard pods
 	selector, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
 	if err != nil {
-		log.Info("Could not parse PDB selector, "+errNoEtcdChec, "selector", pdb.Spec.Selector.String())
+		log.Info(fmt.Sprintf("Could not parse PDB selector, %s", errNoEtcdCheck), "selector", pdb.Spec.Selector.String())
 		return false, err
 	}
 	podList := &corev1.PodList{}
@@ -65,15 +65,15 @@ func CanNodeDisruptEtcd(ctx context.Context, cl client.Client, node *corev1.Node
 		if pod.Spec.NodeName == node.Name {
 			for _, condition := range pod.Status.Conditions {
 				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
-					log.Info("Node is disrupted, so it won't violate etcd quorum", "Node", node.Name, "Guard pod", pod.Name)
+					log.Info("Node is disrupted, thus it won't violate the etcd quorum", "Node", node.Name, "Guard pod", pod.Name)
 					return true, nil
 				}
 			}
-			log.Info("Node is not disrupted, but it will violate etcd quorum", "Node", node.Name, "Guard pod", pod.Name)
+			log.Info("Node is not disrupted, and it will violate the etcd quorum", "Node", node.Name, "Guard pod", pod.Name)
 			return false, nil
 		}
 	}
 
-	log.Info("Node is not disrupted, but it will violate etcd quorum", "Node", node.Name)
-	return false, nil
+	log.Info("No guard pod was found, thus the node is either already disrupted or it wasn't configured with etcd, thus it won't violate the etcd quorum", "Node", node.Name)
+	return true, nil
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -11,6 +11,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// Important: add the following two lines in your project/code, so your RBAC will be updated with the right permissions
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
 const (
 	etcdNamespace = "openshift-etcd"
 	errNoEtcdChec = "can't check if etcd quorum will be violated!"

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1,0 +1,67 @@
+package etcd
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const etcdNamespace = "openshift-etcd"
+
+// IsEtcdDisruptionAllowed checks if etcd disruption is allowed and accpet/refuse the todoAction (remediation/manitenance)
+func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, node *corev1.Node, todoAction string) (bool, error) {
+	log := log.Log.WithName("etcd-pdb-checker")
+	pdbList := &policyv1.PodDisruptionBudgetList{}
+	if err := cl.List(ctx, pdbList, &client.ListOptions{Namespace: etcdNamespace}); err != nil {
+		return false, err
+	}
+	if len(pdbList.Items) == 0 {
+		log.Info("No PDB found, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "namespace", etcdNamespace)
+		return false, nil
+	}
+	if len(pdbList.Items) > 1 {
+		log.Info("More than one PDB found, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "namespace", etcdNamespace)
+		return false, nil
+	}
+	pdb := pdbList.Items[0]
+	if pdb.Status.DisruptionsAllowed >= 1 {
+		log.Info("Etcd disruption is allowed, so "+todoAction+" is allowed", "Node", node.Name)
+		return true, nil
+	}
+
+	// No disruptions allowed, so the only case we should remediate is that the node in question is already one of the disrupted ones
+	// The PDB doesn't disclose which node is disrupted
+	// So we have to check the etcd guard pods
+	selector, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
+	if err != nil {
+		log.Info("Could not parse PDB selector, can't check if etcd quorum will be violated! Refusing "+todoAction+"!", "selector", pdb.Spec.Selector.String())
+		return false, nil
+	}
+	podList := &corev1.PodList{}
+	if err := cl.List(ctx, podList, &client.ListOptions{
+		Namespace:     etcdNamespace,
+		LabelSelector: labels.SelectorFromSet(selector),
+	}); err != nil {
+		return false, err
+	}
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == node.Name {
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+					log.Info("Etcd disruption is not allowed, but the node is already disrupted, so "+todoAction+" is allowed", "Node", node.Name, "Guard pod", pod.Name)
+					return true, nil
+				}
+			}
+			log.Info("Etcd disruption is not allowed, but the node is not disrupted, so "+todoAction+" is not allowed", "Node", node.Name, "Guard pod", pod.Name)
+			return false, nil
+		}
+	}
+
+	log.Info("Etcd disruption is not allowed, and node is not already disrupted, so "+todoAction+" is not allowed", "Node", node.Name)
+	return false, nil
+}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1,4 +1,5 @@
-// etcd package is used for checking whether etcd disruption is allowd
+// Package etcd is used for checking whether etcd disruption is allowd
+//
 // Important: add the following two lines in your project/code, so your RBAC will be updated with the right permissions
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch

--- a/pkg/etcd/etcd_suite_test.go
+++ b/pkg/etcd/etcd_suite_test.go
@@ -10,15 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// var (
-// 	cfg *rest.Config
-// 	testEnv *envtest.Environment
-// 	k8sClient client.Client
-// 	k8sManager   manager.Manager
-// 	ctx          context.Context
-// 	cancel       context.CancelFunc
-// )
-
 func TestEtcd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Etcd Suite")
@@ -33,54 +24,3 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	// call stop or refactor when moving to "normal" testEnv test
 })
-
-// var _ = BeforeSuite(func() {
-// 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-// 	testScheme := runtime.NewScheme()
-
-// 	By("bootstrapping test environment")
-// 	testEnv = &envtest.Environment{
-// 		CRDInstallOptions: envtest.CRDInstallOptions{
-// 			Scheme: testScheme,
-// 			Paths: []string{
-// 				filepath.Join("..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
-// 				filepath.Join("..", "config", "crd", "bases"),
-// 			},
-// 			ErrorIfPathMissing: true,
-// 		},
-// 	}
-
-// 	var err error
-// 	cfg, err = testEnv.Start()
-// 	Expect(err).NotTo(HaveOccurred())
-// 	Expect(cfg).NotTo(BeNil())
-
-// 	//+kubebuilder:scaffold:scheme
-
-// 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: testScheme})
-// 	Expect(err).NotTo(HaveOccurred())
-
-// 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-// 	Expect(err).NotTo(HaveOccurred())
-// 	Expect(k8sClient).NotTo(BeNil())
-// 	// err = (&etcdReconcile{
-// 	// 	client:   k8sClient,
-// 	// 	scheme:   k8sManager.GetScheme(),
-// 	// }).SetupWithManager(k8sManager)
-// 	// Expect(err).NotTo(HaveOccurred())
-
-// 	go func() {
-// 		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
-// 		ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
-// 		err := k8sManager.Start(ctx)
-// 		Expect(err).NotTo(HaveOccurred())
-// 	}()
-// })
-
-// var _ = AfterSuite(func() {
-// 	By("tearing down the test environment")
-// 	cancel()
-// 	err := testEnv.Stop()
-// 	Expect(err).NotTo(HaveOccurred())
-// })

--- a/pkg/etcd/etcd_suite_test.go
+++ b/pkg/etcd/etcd_suite_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -16,7 +17,11 @@ func TestEtcd(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
+	}
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
 
 	// call start or refactor when moving to "normal" testEnv test
 })

--- a/pkg/etcd/etcd_suite_test.go
+++ b/pkg/etcd/etcd_suite_test.go
@@ -1,0 +1,86 @@
+package etcd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// var (
+// 	cfg *rest.Config
+// 	testEnv *envtest.Environment
+// 	k8sClient client.Client
+// 	k8sManager   manager.Manager
+// 	ctx          context.Context
+// 	cancel       context.CancelFunc
+// )
+
+func TestEtcd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Etcd Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// call start or refactor when moving to "normal" testEnv test
+})
+
+var _ = AfterSuite(func() {
+	// call stop or refactor when moving to "normal" testEnv test
+})
+
+// var _ = BeforeSuite(func() {
+// 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+// 	testScheme := runtime.NewScheme()
+
+// 	By("bootstrapping test environment")
+// 	testEnv = &envtest.Environment{
+// 		CRDInstallOptions: envtest.CRDInstallOptions{
+// 			Scheme: testScheme,
+// 			Paths: []string{
+// 				filepath.Join("..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
+// 				filepath.Join("..", "config", "crd", "bases"),
+// 			},
+// 			ErrorIfPathMissing: true,
+// 		},
+// 	}
+
+// 	var err error
+// 	cfg, err = testEnv.Start()
+// 	Expect(err).NotTo(HaveOccurred())
+// 	Expect(cfg).NotTo(BeNil())
+
+// 	//+kubebuilder:scaffold:scheme
+
+// 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: testScheme})
+// 	Expect(err).NotTo(HaveOccurred())
+
+// 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+// 	Expect(err).NotTo(HaveOccurred())
+// 	Expect(k8sClient).NotTo(BeNil())
+// 	// err = (&etcdReconcile{
+// 	// 	client:   k8sClient,
+// 	// 	scheme:   k8sManager.GetScheme(),
+// 	// }).SetupWithManager(k8sManager)
+// 	// Expect(err).NotTo(HaveOccurred())
+
+// 	go func() {
+// 		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+// 		ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
+// 		err := k8sManager.Start(ctx)
+// 		Expect(err).NotTo(HaveOccurred())
+// 	}()
+// })
+
+// var _ = AfterSuite(func() {
+// 	By("tearing down the test environment")
+// 	cancel()
+// 	err := testEnv.Stop()
+// 	Expect(err).NotTo(HaveOccurred())
+// })

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -1,0 +1,166 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonLabels "github.com/medik8s/common/pkg/labels"
+)
+
+var _ = Describe("Check ETCD disruptions", func() {
+	var (
+		cl client.WithWatch
+	)
+
+	When("ETCD PDB was not set", func() {
+		It("should fail", func() {
+			cl = fake.NewClientBuilder().WithRuntimeObjects().Build()
+			valid, _ := IsEtcdDisruptionAllowed(context.Background(), cl, nil, "remediation")
+			Expect(valid).To(BeFalse())
+		})
+	})
+	When("ETCD PDB was set", func() {
+		var (
+			pdb               *policyv1.PodDisruptionBudget
+			controlPlaneNodes []*corev1.Node
+			nodeGuardDown     string
+			// controlPlaneNodes, workerNodes [] corev1.Node
+		)
+
+		BeforeEach(func() {
+			cl = fake.NewClientBuilder().WithRuntimeObjects().Build()
+			pdb = getPDBEtcd()
+			Expect(cl.Create(context.Background(), pdb)).To(Succeed())
+			pdb.Status.DisruptionsAllowed = int32(1)
+			Expect(cl.Status().Update(context.Background(), pdb)).To(Succeed())
+			DeferCleanup(cl.Delete, context.Background(), pdb)
+		})
+		JustBeforeEach(func() {
+			controlPlaneNodes = newControlPlaneNodes(3)
+			for _, node := range controlPlaneNodes {
+				Expect(cl.Create(context.Background(), node)).To(Succeed())
+				podGuard := getPogGuard(node.Name)
+				Expect(cl.Create(context.Background(), podGuard)).To(Succeed())
+			}
+			DeferCleanup(func() {
+				for _, node := range controlPlaneNodes {
+					podGuard := getPogGuard(node.Name)
+					Expect(cl.Delete(context.Background(), podGuard)).To(Succeed())
+					Expect(cl.Delete(context.Background(), node)).To(Succeed())
+				}
+			})
+		})
+		It("should allow remediation for healhy cluster", func() {
+			pdb.Status.DisruptionsAllowed = int32(1)
+			Expect(cl.Status().Update(context.Background(), pdb)).To(Succeed())
+			for _, node := range controlPlaneNodes {
+				Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeTrue())
+			}
+
+			// Expect(IsEtcdDisruptionAllowed(context.Background(), cl, &workerNodes[1], "remediation")).To(BeTrue())
+		})
+		It("should allow remediation for one unhealthy control plane that is not violating quorum and reject others", func() {
+			nodeGuardDown = controlPlaneNodes[2].Name
+			pdb.Status.DisruptionsAllowed = int32(0)
+			Expect(cl.Status().Update(context.Background(), pdb)).To(Succeed())
+			dummyPodGuard := getPogGuard(nodeGuardDown)
+			podGuard := &corev1.Pod{}
+			Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(dummyPodGuard), podGuard)).To(Succeed())
+			podGuard.Status.Conditions[0].Status = corev1.ConditionFalse
+			Expect(cl.Status().Update(context.Background(), podGuard)).To(Succeed())
+			for _, node := range controlPlaneNodes {
+				if node.Name == nodeGuardDown {
+					Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeTrue())
+				} else {
+					Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeFalse())
+				}
+			}
+		})
+	})
+})
+
+func getPogGuard(nodeName string) *corev1.Pod {
+	dummyContainer := corev1.Container{
+		Name:  "container- name",
+		Image: "foo",
+	}
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guard-" + nodeName,
+			Namespace: etcdNamespace,
+			Labels: map[string]string{
+				"app": "guard",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				dummyContainer,
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func getPDBEtcd() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-guard-pdb",
+			Namespace: etcdNamespace,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "guard",
+				},
+			},
+		},
+	}
+}
+
+func newControlPlaneNodes(nodesCount int) []*corev1.Node {
+	nodes := make([]*corev1.Node, 0, nodesCount)
+	for i := nodesCount; i > 0; i-- {
+		node := newNode(fmt.Sprintf("control-plane-node-%d", i), corev1.NodeReady, corev1.ConditionUnknown)
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+func newNode(name string, t corev1.NodeConditionType, s corev1.ConditionStatus) *corev1.Node {
+	labels := make(map[string]string, 1)
+	labels[commonLabels.ControlPlaneRole] = ""
+	return &corev1.Node{
+		TypeMeta: metav1.TypeMeta{Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   t,
+					Status: s,
+				},
+			},
+		},
+	}
+}

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -6,14 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	zaplog "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	commonLabels "github.com/medik8s/common/pkg/labels"
 )
@@ -25,11 +24,7 @@ const (
 var guardLabel = map[string]string{"app": "guard"}
 
 var _ = Describe("Check if etcd disruption is allowed", func() {
-	opts := zaplog.Options{
-		Development: true,
-		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
-	}
-	log := zaplog.New(zaplog.WriteTo(GinkgoWriter), zaplog.UseFlagOptions(&opts))
+	log := ctrl.Log.WithName("etcd-unit-test")
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects().Build()
 
 	BeforeEach(func() {

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Check ETCD disruptions", func() {
 	When("ETCD PDB was not set", func() {
 		It("should fail", func() {
 			cl = fake.NewClientBuilder().WithRuntimeObjects().Build()
-			valid, _ := IsEtcdDisruptionAllowed(context.Background(), cl, nil, "remediation")
+			valid, _ := IsControlPlaneNodeReady(context.Background(), cl, nil, "remediation")
 			Expect(valid).To(BeFalse())
 		})
 	})
@@ -63,7 +63,7 @@ var _ = Describe("Check ETCD disruptions", func() {
 			pdb.Status.DisruptionsAllowed = int32(1)
 			Expect(cl.Status().Update(context.Background(), pdb)).To(Succeed())
 			for _, node := range controlPlaneNodes {
-				Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeTrue())
+				Expect(IsControlPlaneNodeReady(context.Background(), cl, node, "remediation")).To(BeTrue())
 			}
 
 			// Expect(IsEtcdDisruptionAllowed(context.Background(), cl, &workerNodes[1], "remediation")).To(BeTrue())
@@ -79,9 +79,9 @@ var _ = Describe("Check ETCD disruptions", func() {
 			Expect(cl.Status().Update(context.Background(), podGuard)).To(Succeed())
 			for _, node := range controlPlaneNodes {
 				if node.Name == nodeGuardDown {
-					Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeTrue())
+					Expect(IsControlPlaneNodeReady(context.Background(), cl, node, "remediation")).To(BeTrue())
 				} else {
-					Expect(IsEtcdDisruptionAllowed(context.Background(), cl, node, "remediation")).To(BeFalse())
+					Expect(IsControlPlaneNodeReady(context.Background(), cl, node, "remediation")).To(BeFalse())
 				}
 			}
 		})


### PR DESCRIPTION
New function (with tests) for ETCD quorum violation check.
It can accept/refuse Control Plane remediation/maintenance (NHC/NMO respectively) for any control plane node.
It begins with checking if etcd quorum exists and it allows disruptions.
If it exists but no disruptions are allowed then it checks if the given node is disrupted (guard pod status is _False_). When the given node is indeed disrupted and no etcd quorum violations are accepted, then the node can be disrupted as it won't violate the quorum, otherwise, any other control plane node disruption will violate the quorum.
