### PR TITLE
Add new GetTargetNodeFailed event

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -35,17 +35,17 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // Special case events
 
-// RemediationStarted will record a Normal event with reason RemediationStarted and message Remediation started.
+// RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
 }
 
-// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped.
+// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
 }
 
-// RemediationFinished will record a Normal event with reason RemediationFinished and message Remediation finished.
+// RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -49,3 +49,8 @@ func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Objec
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
 }
+
+// GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
+func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
+	WarningEvent(recorder, object, "RemediationCannotStart", "Could not get remediation target Node")
+}

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -25,6 +25,13 @@ var _ = Describe("Emit custom formatted Event", func() {
 			})
 		})
 
+		When("Remediation could not get target Node", func() {
+			It("should see special GetTargetNodeFailed event", func() {
+				GetTargetNodeFailed(r, nil)
+				verifyEvent(r, "Warning RemediationCannotStart [remediation] Could not get remediation target Node")
+			})
+		})
+
 		When("Remediation is stopped by NHC", func() {
 			It("should see special RemediationStoppedByNHC event", func() {
 				RemediationStoppedByNHC(r, nil)


### PR DESCRIPTION
- Add tests for special event API
- Minor fixes to special events API documentation
- Add new GetTargetNodeFailed event

see: https://issues.redhat.com/browse/ECOPROJECT-1838
