### PR TITLE
events: replace string literals with variables

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -22,7 +22,7 @@ const (
 	remediationCannotStartTargetNodeFailedEventMessage = "Could not get remediation target Node"
 )
 
-// NormalEvent will record an event with type Normal and fixed message.
+// NormalEvent will record an event with type Normal and custom message.
 func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
 	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
@@ -33,7 +33,7 @@ func NormalEventf(recorder record.EventRecorder, object runtime.Object, reason, 
 	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
 
-// WarningEvent will record an event with type Warning and fixed message.
+// WarningEvent will record an event with type Warning and custom message.
 func WarningEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
 	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
 }
@@ -46,27 +46,29 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // Special case events
 
-// RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
+// RemediationStarted will record a Normal event to signal that the remediation has started.
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, RemediationStartedEventReason, remediationStartedEventMessage)
 }
 
-// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
+// RemediationStoppedByNHC will record a Normal event to signal that the remediation was stopped by the Node Healthcheck operator.
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, RemediationStoppedEventReason, remediationStoppedEventMessage)
 }
 
-// RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
+// RemediationFinished will record a Normal event to signal that the remediation has finished.
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, RemediationFinishedEventReason, remediationFinishedEventMessage)
 }
 
-// RemediationCannotStart will record a Warning event with reason RemediationCannotStart and custom message.
+// RemediationCannotStart will record a Warning event to signal that the remediation cannot start. A custom message can
+// be used to further explain the reason.
 func RemediationCannotStart(recorder record.EventRecorder, object runtime.Object, message string) {
 	WarningEvent(recorder, object, RemediationCannotStartEventReason, message)
 }
 
-// GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
+// GetTargetNodeFailed will record a Warning event to signal that the remediation cannot start because the target Node
+// could not be found.
 func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
 	RemediationCannotStart(recorder, object, remediationCannotStartTargetNodeFailedEventMessage)
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -9,7 +9,18 @@ import (
 )
 
 // Event message format "medik8s <operator shortname> <message>"
-const customFmt = "[remediation] %s"
+const (
+	customFmt = "[remediation] %s"
+
+	RemediationStartedEventReason                      = "RemediationStarted"
+	RemediationStoppedEventReason                      = "RemediationStopped"
+	RemediationFinishedEventReason                     = "RemediationFinished"
+	RemediationCannotStartEventReason                  = "RemediationCannotStart"
+	remediationStartedEventMessage                     = "Remediation started"
+	remediationStoppedEventMessage                     = "NHC added the timed-out annotation, remediation will be stopped"
+	remediationFinishedEventMessage                    = "Remediation finished"
+	remediationCannotStartTargetNodeFailedEventMessage = "Could not get remediation target Node"
+)
 
 // NormalEvent will record an event with type Normal and fixed message.
 func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
@@ -37,20 +48,25 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
+	NormalEvent(recorder, object, RemediationStartedEventReason, remediationStartedEventMessage)
 }
 
 // RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
+	NormalEvent(recorder, object, RemediationStoppedEventReason, remediationStoppedEventMessage)
 }
 
 // RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+	NormalEvent(recorder, object, RemediationFinishedEventReason, remediationFinishedEventMessage)
+}
+
+// RemediationCannotStart will record a Warning event with reason RemediationCannotStart and custom message.
+func RemediationCannotStart(recorder record.EventRecorder, object runtime.Object, message string) {
+	WarningEvent(recorder, object, RemediationCannotStartEventReason, message)
 }
 
 // GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
 func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
-	WarningEvent(recorder, object, "RemediationCannotStart", "Could not get remediation target Node")
+	RemediationCannotStart(recorder, object, remediationCannotStartTargetNodeFailedEventMessage)
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -32,6 +32,13 @@ var _ = Describe("Emit custom formatted Event", func() {
 			})
 		})
 
+		When("Remediation could not start", func() {
+			It("should see special RemediationCannotStart event with custom reason", func() {
+				RemediationCannotStart(r, nil, "custom event message")
+				verifyEvent(r, "Warning RemediationCannotStart [remediation] custom event message")
+			})
+		})
+
 		When("Remediation is stopped by NHC", func() {
 			It("should see special RemediationStoppedByNHC event", func() {
 				RemediationStoppedByNHC(r, nil)


### PR DESCRIPTION
Add variables for event reasons and messages to allow reuse of the same
messages and help tests.

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
