### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -15,7 +15,7 @@ jobs: # jobs to run
     runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -12,7 +12,7 @@ on: # on events
 jobs: # jobs to run
   build:
     name: Test
-    runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: ubuntu-24.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
#### Why we need this PR
Modernize GitHub Actions to current stable versions.

#### Changes made
- Bump `actions/checkout` from v3 to v6
- Update runner image from ubuntu-22.04 to ubuntu-24.04

#### Which issue(s) this PR fixes
Contributes to [RHWA-852](https://redhat.atlassian.net/browse/RHWA-852) and [RHWA-853](https://redhat.atlassian.net/browse/RHWA-853)

#### Test plan
- CI pre-submit passes with updated action versions